### PR TITLE
Fix PDAL pipeline output detection

### DIFF
--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -20,7 +20,9 @@ def run_pdal_pipeline(config_path="../config/pdal_pipeline_preprocess.json"):
 
     # Try to find the output file from the pipeline definition
     output_file = None
-    for stage in pipeline_def:
+    # The JSON can be a dictionary with a top-level "pipeline" key
+    stages = pipeline_def.get("pipeline", pipeline_def)
+    for stage in stages:
         if isinstance(stage, dict) and "filename" in stage:
             output_file = stage["filename"]
 


### PR DESCRIPTION
## Summary
- handle JSON configs with top-level `pipeline` key when searching for output files

## Testing
- `python -m py_compile src/preprocess.py src/summary_stats.py`


------
https://chatgpt.com/codex/tasks/task_e_688a750ce638832396dd6c716a3e665d