### PR TITLE
Add PDAL ground filter scripts

### DIFF
--- a/src/csf_filter.py
+++ b/src/csf_filter.py
@@ -1,0 +1,68 @@
+import json
+import os
+import pdal
+
+
+def run_csf(
+    input_file: str,
+    output_file: str,
+    cloth_resolution: float = 0.5,
+    rigidness: int = 2,
+    time_step: float = 0.65,
+) -> str:
+    """Run PDAL Cloth Simulation Filter (CSF).
+
+    Parameters
+    ----------
+    input_file: str
+        Path to input LAS/LAZ file.
+    output_file: str
+        Destination file for filtered result.
+    cloth_resolution: float, optional
+        Resolution of the cloth used in simulation.
+    rigidness: int, optional
+        Rigidness of cloth (1-3).
+    time_step: float, optional
+        Integration time step for simulation.
+
+    Returns
+    -------
+    str
+        Path to the written file.
+    """
+    pipeline_def = {
+        "pipeline": [
+            {"type": "readers.las", "filename": input_file},
+            {
+                "type": "filters.csf",
+                "cloth_resolution": cloth_resolution,
+                "rigidness": rigidness,
+                "time_step": time_step,
+            },
+            {"type": "writers.las", "filename": output_file},
+        ]
+    }
+
+    pipeline = pdal.Pipeline(json.dumps(pipeline_def))
+    pipeline.execute()
+    return os.path.abspath(output_file)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run Cloth Simulation Filter")
+    parser.add_argument("input", help="Input LAS/LAZ file")
+    parser.add_argument("output", help="Output LAS/LAZ file")
+    parser.add_argument("--cloth-resolution", type=float, default=0.5)
+    parser.add_argument("--rigidness", type=int, default=2)
+    parser.add_argument("--time-step", type=float, default=0.65)
+    args = parser.parse_args()
+
+    run_csf(
+        args.input,
+        args.output,
+        cloth_resolution=args.cloth_resolution,
+        rigidness=args.rigidness,
+        time_step=args.time_step,
+    )

--- a/src/pmf_filter.py
+++ b/src/pmf_filter.py
@@ -1,0 +1,75 @@
+import json
+import pdal
+import os
+from typing import Optional
+
+
+def run_pmf(
+    input_file: str,
+    output_file: str,
+    max_window_size: int = 33,
+    slope: float = 1.0,
+    initial_distance: float = 0.5,
+    cell_size: float = 1.0,
+) -> str:
+    """Run PDAL progressive morphological filter.
+
+    Parameters
+    ----------
+    input_file: str
+        Path to input LAS/LAZ file.
+    output_file: str
+        Destination file for filtered result.
+    max_window_size: int, optional
+        Maximum window size used by the filter.
+    slope: float, optional
+        Slope for terrain.
+    initial_distance: float, optional
+        Initial elevation distance.
+    cell_size: float, optional
+        Cell size for morphological operations.
+
+    Returns
+    -------
+    str
+        Path to the written file.
+    """
+    pipeline_def = {
+        "pipeline": [
+            {"type": "readers.las", "filename": input_file},
+            {
+                "type": "filters.pmf",
+                "max_window_size": max_window_size,
+                "slope": slope,
+                "initial_distance": initial_distance,
+                "cell_size": cell_size,
+            },
+            {"type": "writers.las", "filename": output_file},
+        ]
+    }
+
+    pipeline = pdal.Pipeline(json.dumps(pipeline_def))
+    pipeline.execute()
+    return os.path.abspath(output_file)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run Progressive Morphological Filter")
+    parser.add_argument("input", help="Input LAS/LAZ file")
+    parser.add_argument("output", help="Output LAS/LAZ file")
+    parser.add_argument("--max-window-size", type=int, default=33)
+    parser.add_argument("--slope", type=float, default=1.0)
+    parser.add_argument("--initial-distance", type=float, default=0.5)
+    parser.add_argument("--cell-size", type=float, default=1.0)
+    args = parser.parse_args()
+
+    run_pmf(
+        args.input,
+        args.output,
+        max_window_size=args.max_window_size,
+        slope=args.slope,
+        initial_distance=args.initial_distance,
+        cell_size=args.cell_size,
+    )

--- a/src/smrf_filter.py
+++ b/src/smrf_filter.py
@@ -1,0 +1,74 @@
+import json
+import os
+import pdal
+
+
+def run_smrf(
+    input_file: str,
+    output_file: str,
+    window: float = 18.0,
+    slope: float = 0.15,
+    threshold: float = 0.5,
+    window_increment: float = 16.0,
+) -> str:
+    """Run PDAL Simple Morphological Filter (SMRF).
+
+    Parameters
+    ----------
+    input_file: str
+        Path to input LAS/LAZ file.
+    output_file: str
+        Destination file for filtered result.
+    window: float, optional
+        Initial window size for the filter.
+    slope: float, optional
+        Slope parameter for underlying terrain.
+    threshold: float, optional
+        Elevation threshold.
+    window_increment: float, optional
+        Increment applied to window size each step.
+
+    Returns
+    -------
+    str
+        Path to the written file.
+    """
+    pipeline_def = {
+        "pipeline": [
+            {"type": "readers.las", "filename": input_file},
+            {
+                "type": "filters.smrf",
+                "scalar": window_increment,
+                "slope": slope,
+                "threshold": threshold,
+                "window": window,
+            },
+            {"type": "writers.las", "filename": output_file},
+        ]
+    }
+
+    pipeline = pdal.Pipeline(json.dumps(pipeline_def))
+    pipeline.execute()
+    return os.path.abspath(output_file)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run SMRF ground filter")
+    parser.add_argument("input", help="Input LAS/LAZ file")
+    parser.add_argument("output", help="Output LAS/LAZ file")
+    parser.add_argument("--window", type=float, default=18.0)
+    parser.add_argument("--slope", type=float, default=0.15)
+    parser.add_argument("--threshold", type=float, default=0.5)
+    parser.add_argument("--window-increment", type=float, default=16.0)
+    args = parser.parse_args()
+
+    run_smrf(
+        args.input,
+        args.output,
+        window=args.window,
+        slope=args.slope,
+        threshold=args.threshold,
+        window_increment=args.window_increment,
+    )


### PR DESCRIPTION
## Summary
- add PMF, SMRF and CSF filters using PDAL

## Testing
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688a765ef1348323a878428846b6ae7b